### PR TITLE
Group requests

### DIFF
--- a/APIBlueprintGenerator.coffee
+++ b/APIBlueprintGenerator.coffee
@@ -7,6 +7,8 @@
 )(this)
 
 APIBlueprintGenerator = ->
+  templateRequest = readFile("apiblueprint-request.mustache")
+  templateGroup = readFile("apiblueprint-group.mustache")
 
   # Generate a response dictionary for the mustache context from a paw HTTPExchange
   #
@@ -101,16 +103,48 @@ APIBlueprintGenerator = ->
 
     path
 
-  @generate = (context) ->
-    paw_request = context.getCurrentRequest()
+  @renderPawItems = (items, level = 1) ->
+    sections = for item in items
+      @renderPawItem(item, level)
+
+    sections.join("\n")
+
+  @renderPawItem = (item, level = 1) ->
+    if item.toString().match(/^RequestGroup/)
+      @renderPawGroup(item, level)
+    else
+      @renderPawRequest(item, level)
+
+  @renderPawGroup = (paw_group, level = 1) ->
+    sections = []
+
+    sections.push Mustache.render(templateGroup,
+      level: "#".repeat(level),
+      name: paw_group.name
+    )
+
+    children = paw_group.getChildren().sort (a, b) -> a.order - b.order
+
+    sections = sections.concat @renderPawItems(children, level + 1)
+
+    sections.join("\n")
+
+  @renderPawRequest = (paw_request, level = 1) ->
     url = paw_request.url
-    template = readFile("apiblueprint.mustache")
-    Mustache.render(template,
+    Mustache.render(templateRequest,
+      level: "#".repeat(level),
+      name: paw_request.name.replace(/[\[\]\(\)]/g, ''),
       method: paw_request.method,
       path: @path(url),
       request: @request(paw_request),
       response: @response(paw_request.getLastExchange()),
     )
+
+  @generate = (context, requests, options) ->
+    if context.runtimeInfo.task == 'exportAllRequests'
+      @renderPawItems(context.getRootRequestTreeItems())
+    else
+      @renderPawItems(requests)
 
   return
 

--- a/Cakefile
+++ b/Cakefile
@@ -27,7 +27,8 @@ build_coffee = (callback) ->
 build_copy = () ->
     fs.writeFileSync "#{ build_dir }/README.md", fs.readFileSync("./README.md")
     fs.writeFileSync "#{ build_dir }/LICENSE", fs.readFileSync("./LICENSE")
-    fs.writeFileSync "#{ build_dir }/apiblueprint.mustache", fs.readFileSync("./apiblueprint.mustache")
+    fs.writeFileSync "#{ build_dir }/apiblueprint-request.mustache", fs.readFileSync("./apiblueprint-request.mustache")
+    fs.writeFileSync "#{ build_dir }/apiblueprint-group.mustache", fs.readFileSync("./apiblueprint-group.mustache")
     fs.writeFileSync "#{ build_dir }/mustache.js", fs.readFileSync("./node_modules/mustache/mustache.js")
 
 # build: build CoffeeScript and copy files to build directory

--- a/apiblueprint-group.mustache
+++ b/apiblueprint-group.mustache
@@ -1,0 +1,1 @@
+{{{ level }}} Group {{{ name }}}

--- a/apiblueprint-request.mustache
+++ b/apiblueprint-request.mustache
@@ -1,4 +1,4 @@
-# {{{ method }}} {{{ path }}}
+{{{ level }}} {{{ name }}} [{{{ method }}} {{{ path }}}]
 
 {{#request.description?}}
 {{{request.description}}}


### PR DESCRIPTION
When exporting all requests, group them according to the same layout as
defined in Paw.  This implementation was inspired by the
Paw-PostmanCollectionV2Generator [1].

Fixes: Issue #27

[1]: https://github.com/luckymarmot/Paw-PostmanCollectionV2Generator